### PR TITLE
Add support for Tox (http://tox.testrun.org/) and Travis CI (http://about.travis-ci.org/)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - 2.6
+  - 2.7
+before_install: pip install --use-mirrors zc.buildout==1.6.3
+install: python setup.py install
+script: python setup.py test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.txt
+include CHANGES.txt
+recursive-include hexagonit *

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27
+
+[testenv]
+commands = python setup.py test
+deps =
+    zc.buildout==1.6.3


### PR DESCRIPTION
This adds the ability to run the tests against multiple versions of Python using [Tox](http://tox.testrun.org/) (a local tool) and [Travis CI](http://about.travis-ci.org/) (a cloud-based CI system).

This was done with an eye towards perhaps eventually making `hexagonit.recipe.cmmi` work with Python 3 -- not sure if folks are already working on that?
