### PR TITLE
Remove compile directory if it exists before downloading source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist
+*.pyc
+hexagonit.recipe.cmmi.egg-info

--- a/hexagonit/recipe/cmmi/__init__.py
+++ b/hexagonit/recipe/cmmi/__init__.py
@@ -128,14 +128,11 @@ class Recipe(object):
         # Download the source using hexagonit.recipe.download
         if self.options['url']:
             compile_dir = self.options['compile-directory']
-            try:
-                os.mkdir(compile_dir)
-            except OSError, e:
-                # leftovers from a previous failed attempt,
-                # download recipe will raise a clean error message
-                if e.errno != errno.EEXIST:
-                    raise
-
+            if os.path.exists(compile_dir):
+                # leftovers from a previous failed attempt, removing it.
+                log.warning('Removing already existing directory %s' % compile_dir)
+                shutil.rmtree(compile_dir)
+            os.mkdir(compile_dir)
             try:
                 opt = self.options.copy()
                 opt['destination'] = compile_dir

--- a/hexagonit/recipe/cmmi/tests.py
+++ b/hexagonit/recipe/cmmi/tests.py
@@ -116,10 +116,6 @@ class NonInformativeTests(unittest.TestCase):
             # expected failure
             self.assertRaises(zc.buildout.UserError, recipe.install)
 
-            # User deletes the __compile__ path
-            build_directory = os.path.join(self.dir, 'test_parts/test__compile__')
-            shutil.rmtree(build_directory)
-
             # the install should still fail, and _not_ raise an OSError
             self.assertRaises(zc.buildout.UserError, recipe.install)
         finally:


### PR DESCRIPTION
Fix annoying behavior where, after a failed compilation, it is needed to run buildout to have the compile-directory removed but have an error message, then run it again to try to compile again.

Update tests to show this wanted behavior.

Also include a .gitignore file, as a bonus.

Maybe old behavior is a planned behavior, but in this case, the code is anyway not valid, because the directory will be anyway deleted after one buildout run.
