### PR TITLE
except .. as ..

### DIFF
--- a/hexagonit/recipe/cmmi/__init__.py
+++ b/hexagonit/recipe/cmmi/__init__.py
@@ -95,7 +95,7 @@ class Recipe(object):
             elif retcode > 0:
                 log.error('Command failed with exit code %s: %s' % (retcode, cmd))
                 raise zc.buildout.UserError('System error')
-        except OSError, e:
+        except OSError as e:
             log.error('Command failed: %s: %s' % (e, cmd))
             raise zc.buildout.UserError('System error')
 
@@ -148,7 +148,7 @@ class Recipe(object):
         current_dir = os.getcwd()
         try:
             os.mkdir(self.options['location'])
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.EEXIST:
                 pass
         os.chdir(compile_dir)

--- a/hexagonit/recipe/cmmi/tests.py
+++ b/hexagonit/recipe/cmmi/tests.py
@@ -48,7 +48,7 @@ class NonInformativeTests(unittest.TestCase):
         parts_directory_path = os.path.join(self.dir, 'test_parts')
         try:
             os.mkdir(parts_directory_path)
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
         bo = {
@@ -167,7 +167,7 @@ class NonInformativeTests(unittest.TestCase):
         try:
             recipe.call_script('%s:my_hook' % filename)
             self.fail("The hook script was not called.")
-        except ValueError, e:
+        except ValueError as e:
             self.assertEquals(str(e), 'I got called')
 
     def test_call_script__augmented_environment_as_third_parameter(self):
@@ -189,7 +189,7 @@ class NonInformativeTests(unittest.TestCase):
         try:
             recipe.call_script('%s:my_hook' % filename)
             self.fail("The hook script was not called.")
-        except ValueError, e:
+        except ValueError as e:
             self.assertEquals(str(e), 'sentinel bar')
 
 


### PR DESCRIPTION
This replaces the "except Exception, e" syntax that does not work under Python 3.
