### PR TITLE
Fix ascii decode error by making sure file is read is utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ name = 'hexagonit.recipe.cmmi'
 
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    return open(os.path.join(os.path.dirname(__file__), *rnames), encoding="utf8").read()
 
 
 setup(


### PR DESCRIPTION
Fixes the following problem:

```
Traceback (most recent call last):
  File "/tmp/tmpjox0rjsr", line 14, in <module>
    exec(compile(f.read(), '/home/xmpp/src/hexagonit.recipe.cmmi/setup.py', 'exec'))
  File "/home/xmpp/src/hexagonit.recipe.cmmi/setup.py", line 25, in <module>
    + '\n' +
  File "/home/xmpp/src/hexagonit.recipe.cmmi/setup.py", line 9, in read
    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 16938: ordinal not in range(128)
While:
  Installing.
  Processing develop directory '/home/xmpp/src/hexagonit.recipe.cmmi'.
```

CC @dokai 